### PR TITLE
Making the port number from node_exporter optional

### DIFF
--- a/jobstats/views.py
+++ b/jobstats/views.py
@@ -1100,7 +1100,7 @@ def graph_disk_iops(request, username, job_id):
     data = {'lines': []}
     step = sanitize_step(request, minimum="3m")
 
-    query_read = 'rate(node_disk_reads_completed_total{{instance=~"{}(:9100)?",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
+    query_read = 'rate(node_disk_reads_completed_total{{instance=~"{}(:.*)?",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
     stats_read = prom.query_prometheus_multiple(query_read, job.time_start_dt(), job.time_end_dt(), step=step)
     for line in stats_read:
         compute_name = "{} {}".format(
@@ -1116,7 +1116,7 @@ def graph_disk_iops(request, username, job_id):
             'hovertemplate': '%{y:.1f} IOPS',
         })
 
-    query_write = 'rate(node_disk_writes_completed_total{{instance=~"{}(:9100)",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
+    query_write = 'rate(node_disk_writes_completed_total{{instance=~"{}(:.*)",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
     stats_write = prom.query_prometheus_multiple(query_write, job.time_start_dt(), job.time_end_dt(), step=step)
     for line in stats_write:
         compute_name = "{} {}".format(
@@ -1155,7 +1155,7 @@ def graph_disk_bdw(request, username, job_id):
     data = {'lines': []}
     step = sanitize_step(request, minimum="3m")
 
-    query_read = 'rate(node_disk_read_bytes_total{{instance=~"{instances}(:9100)?",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
+    query_read = 'rate(node_disk_read_bytes_total{{instance=~"{instances}(:.*)?",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1174,7 +1174,7 @@ def graph_disk_bdw(request, username, job_id):
             'hovertemplate': '%{y:.1f}',
         })
 
-    query_write = '-rate(node_disk_written_bytes_total{{instance=~"{instances}(:9100)?",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
+    query_write = '-rate(node_disk_written_bytes_total{{instance=~"{instances}(:.*)?",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1216,7 +1216,7 @@ def graph_disk_used(request, username, job_id):
 
     data = {'lines': []}
 
-    query_disk = '(node_filesystem_size_bytes{{instance=~"{instances}(:9100)?",mountpoint="/localscratch", {filter}}} - node_filesystem_avail_bytes{{instance=~"{instances}(:9100)?",mountpoint="/localscratch", {filter}}})/(1000*1000*1000)'.format(
+    query_disk = '(node_filesystem_size_bytes{{instance=~"{instances}(:.*)?",mountpoint="/localscratch", {filter}}} - node_filesystem_avail_bytes{{instance=~"{instances}(:.*)?",mountpoint="/localscratch", {filter}}})/(1000*1000*1000)'.format(
         instances=instances,
         filter=prom.get_filter())
     stats_disk = prom.query_prometheus_multiple(query_disk, job.time_start_dt(), job.time_end_dt(), step=sanitize_step(request))
@@ -1264,7 +1264,7 @@ def power(job, step):
         # ( take the node power)
         # * (the ratio of cpu cores allocated in that node)
         query = '(label_replace(sum(redfish_chassis_power_average_consumed_watts{{instance=~"({nodes})-oob", {filter} }}) by (instance), "instance", "$1", "instance", "(.*)-oob") ) \
-            * ( label_replace(count(slurm_job_core_usage_total{{slurmjobid="{jobid}", {filter}}} / 1000) by (instance),"instance", "$1", "instance", "(.*):.*") / label_replace((count(node_cpu_seconds_total{{instance=~"({nodes}):9100", mode="idle", {filter}}} / 1000) by (instance)), "instance", "$1", "instance", "(.*):.*") )'.format(
+            * ( label_replace(count(slurm_job_core_usage_total{{slurmjobid="{jobid}", {filter}}} / 1000) by (instance),"instance", "$1", "instance", "(.*):.*") / label_replace((count(node_cpu_seconds_total{{instance=~"({nodes})(:.*)?", mode="idle", {filter}}} / 1000) by (instance)), "instance", "$1", "instance", "(.*):.*") )'.format(
             nodes='|'.join(nodes),
             filter=prom.get_filter(),
             jobid=job.id_job,

--- a/jobstats/views.py
+++ b/jobstats/views.py
@@ -333,9 +333,9 @@ def graph_cpu(request, username, job_id):
         x = list(map(lambda x: x.strftime('%Y-%m-%d %H:%M:%S'), line['x']))
         y = line['y']
         if context['multiple_jobs']:
-            name = '{} {} core {}'.format(line['metric']['slurmjobid'], compute_name, core_num)
+            name = '{} core {} {}'.format(line['metric']['slurmjobid'], core_num, compute_name)
         else:
-            name = 'core {}'.format(core_num)
+            name = 'core {} {}'.format(core_num, compute_name)
         data['lines'].append({
             'x': x,
             'y': y,
@@ -1037,7 +1037,7 @@ def graph_infiniband_bdw(request, username, job_id):
     except JobTable.DoesNotExist:
         return HttpResponseNotFound('Job not found')
     nodes = job.nodes()
-    instances = '|'.join([s + ':9100' for s in nodes])
+    instances = '|'.join([s + '(:.*)?' for s in nodes])
 
     data = {'lines': []}
     step = sanitize_step(request, minimum="3m")
@@ -1095,12 +1095,12 @@ def graph_disk_iops(request, username, job_id):
     except JobTable.DoesNotExist:
         return HttpResponseNotFound('Job not found')
     nodes = job.nodes()
-    instances = '|'.join(nodes)
+    instances = '|'.join([s + '(:.*)?' for s in nodes])
 
     data = {'lines': []}
     step = sanitize_step(request, minimum="3m")
 
-    query_read = 'rate(node_disk_reads_completed_total{{instance=~"{}(:.*)?",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
+    query_read = 'rate(node_disk_reads_completed_total{{instance=~"{}",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
     stats_read = prom.query_prometheus_multiple(query_read, job.time_start_dt(), job.time_end_dt(), step=step)
     for line in stats_read:
         compute_name = "{} {}".format(
@@ -1116,7 +1116,7 @@ def graph_disk_iops(request, username, job_id):
             'hovertemplate': '%{y:.1f} IOPS',
         })
 
-    query_write = 'rate(node_disk_writes_completed_total{{instance=~"{}(:.*)",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
+    query_write = 'rate(node_disk_writes_completed_total{{instance=~"{}",device=~"nvme.n.|sd.|vd.", {}}}[{}])'.format(instances, prom.get_filter(), step)
     stats_write = prom.query_prometheus_multiple(query_write, job.time_start_dt(), job.time_end_dt(), step=step)
     for line in stats_write:
         compute_name = "{} {}".format(
@@ -1150,12 +1150,12 @@ def graph_disk_bdw(request, username, job_id):
     except JobTable.DoesNotExist:
         return HttpResponseNotFound('Job not found')
     nodes = job.nodes()
-    instances = '|'.join(nodes)
+    instances = '|'.join([s + '(:.*)?' for s in nodes])
 
     data = {'lines': []}
     step = sanitize_step(request, minimum="3m")
 
-    query_read = 'rate(node_disk_read_bytes_total{{instance=~"{instances}(:.*)?",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
+    query_read = 'rate(node_disk_read_bytes_total{{instance=~"{instances}",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1174,7 +1174,7 @@ def graph_disk_bdw(request, username, job_id):
             'hovertemplate': '%{y:.1f}',
         })
 
-    query_write = '-rate(node_disk_written_bytes_total{{instance=~"{instances}(:.*)?",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
+    query_write = '-rate(node_disk_written_bytes_total{{instance=~"{instances}",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}])'.format(
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1212,11 +1212,11 @@ def graph_disk_used(request, username, job_id):
     except JobTable.DoesNotExist:
         return HttpResponseNotFound('Job not found')
     nodes = job.nodes()
-    instances = '|'.join(nodes)
+    instances = '|'.join([s + '(:.*)?' for s in nodes])
 
     data = {'lines': []}
 
-    query_disk = '(node_filesystem_size_bytes{{instance=~"{instances}(:.*)?",mountpoint="/localscratch", {filter}}} - node_filesystem_avail_bytes{{instance=~"{instances}(:.*)?",mountpoint="/localscratch", {filter}}})/(1000*1000*1000)'.format(
+    query_disk = '(node_filesystem_size_bytes{{instance=~"{instances}",mountpoint="/localscratch", {filter}}} - node_filesystem_avail_bytes{{instance=~"{instances}",mountpoint="/localscratch", {filter}}})/(1000*1000*1000)'.format(
         instances=instances,
         filter=prom.get_filter())
     stats_disk = prom.query_prometheus_multiple(query_disk, job.time_start_dt(), job.time_end_dt(), step=sanitize_step(request))
@@ -1263,11 +1263,13 @@ def power(job, step):
     else:
         # ( take the node power)
         # * (the ratio of cpu cores allocated in that node)
+        nodes_node_exporter = '|'.join([s + '(:.*)?' for s in nodes])
         query = '(label_replace(sum(redfish_chassis_power_average_consumed_watts{{instance=~"({nodes})-oob", {filter} }}) by (instance), "instance", "$1", "instance", "(.*)-oob") ) \
-            * ( label_replace(count(slurm_job_core_usage_total{{slurmjobid="{jobid}", {filter}}} / 1000) by (instance),"instance", "$1", "instance", "(.*):.*") / label_replace((count(node_cpu_seconds_total{{instance=~"({nodes})(:.*)?", mode="idle", {filter}}} / 1000) by (instance)), "instance", "$1", "instance", "(.*):.*") )'.format(
+            * ( label_replace(count(slurm_job_core_usage_total{{slurmjobid="{jobid}", {filter}}} / 1000) by (instance),"instance", "$1", "instance", "(.*):.*") / label_replace((count(node_cpu_seconds_total{{instance=~"({nodes_node_exporter})", mode="idle", {filter}}} / 1000) by (instance)), "instance", "$1", "instance", "(.*):.*") )'.format(
             nodes='|'.join(nodes),
             filter=prom.get_filter(),
             jobid=job.id_job,
+            nodes_node_exporter=nodes_node_exporter,
         )
     return prom.query_prometheus_multiple(query, job.time_start_dt(), job.time_end_dt(), step)
 

--- a/pages/views.py
+++ b/pages/views.py
@@ -122,13 +122,13 @@ def graph_login_cpu(request, login):
         return JsonResponse({'error': 'Unknown login node'})
     timing = query_time(request)
 
-    core_count_query = 'count(node_cpu_seconds_total{{mode="system",instance=~"{login}:.*", {filter} }})'.format(
+    core_count_query = 'count(node_cpu_seconds_total{{mode="system",instance=~"{login}(:.*)?", {filter} }})'.format(
         login=login,
         filter=prom.get_filter(),
     )
     core_count = max(prom.query_prometheus(core_count_query, timing[0], step=timing[1])[1])
     data = {'lines': []}
-    query = 'sum by (mode)(rate(node_cpu_seconds_total{{mode=~"system|user|iowait",instance=~"{login}:.*", {filter} }}[{step}]))'.format(
+    query = 'sum by (mode)(rate(node_cpu_seconds_total{{mode=~"system|user|iowait",instance=~"{login}(:.*)?", {filter} }}[{step}]))'.format(
         login=login,
         filter=prom.get_filter(),
         step=timing[1],
@@ -173,13 +173,13 @@ def graph_login_memory(request, login):
         return JsonResponse({'error': 'Unknown login node'})
     timing = query_time(request)
 
-    total_mem_query = 'node_memory_MemTotal_bytes{{instance=~"{login}:.*", {filter} }}'.format(
+    total_mem_query = 'node_memory_MemTotal_bytes{{instance=~"{login}(:.*)?", {filter} }}'.format(
         login=login,
         filter=prom.get_filter(),
     )
     total_mem = max(prom.query_prometheus(total_mem_query, timing[0], step=timing[1])[1])
     data = {'lines': []}
-    query = 'node_memory_MemTotal_bytes{{instance=~"{login}:.*", {filter} }} - node_memory_MemFree_bytes{{instance=~"{login}:.*", {filter} }} - node_memory_Buffers_bytes{{instance=~"{login}:.*", {filter} }} - node_memory_Cached_bytes{{instance=~"{login}:.*", {filter} }} - node_memory_Slab_bytes{{instance=~"{login}:.*", {filter} }} - node_memory_PageTables_bytes{{instance=~"{login}:.*", {filter} }} - node_memory_SwapCached_bytes{{instance=~"{login}:.*", {filter} }}'.format(
+    query = 'node_memory_MemTotal_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_MemFree_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_Buffers_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_Cached_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_Slab_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_PageTables_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_SwapCached_bytes{{instance=~"{login}(:.*)?", {filter} }}'.format(
         login=login,
         filter=prom.get_filter(),
     )
@@ -218,7 +218,7 @@ def graph_login_load(request, login):
     timing = query_time(request)
     data = {'lines': []}
 
-    query = 'node_load1{{instance=~"{login}:.*", {filter} }}'.format(
+    query = 'node_load1{{instance=~"{login}(:.*)?", {filter} }}'.format(
         login=login,
         filter=prom.get_filter(),
     )
@@ -267,7 +267,7 @@ def graph_dtn_network(request, dtn):
 def graph_network(request, node, device):
     timing = query_time(request)
     data = {'lines': []}
-    query_rx = 'rate(node_network_receive_bytes_total{{instance=~"{node}:.*", device="{device}", {filter} }}[{step}]) * 8'.format(
+    query_rx = 'rate(node_network_receive_bytes_total{{instance=~"{node}(:.*)?", device="{device}", {filter} }}[{step}]) * 8'.format(
         node=node,
         filter=prom.get_filter(),
         device=device,
@@ -283,7 +283,7 @@ def graph_network(request, node, device):
         'name': '{}'.format('Receive'),
     })
 
-    query_tx = 'rate(node_network_transmit_bytes_total{{instance=~"{node}:.*", device="{device}", {filter} }}[{step}]) * 8'.format(
+    query_tx = 'rate(node_network_transmit_bytes_total{{instance=~"{node}(:.*)?", device="{device}", {filter} }}[{step}]) * 8'.format(
         node=node,
         filter=prom.get_filter(),
         device=device,


### PR DESCRIPTION
Prometheus can sometime have the port number or not in the instance name depending on the configuration of the targets. This will make the code handle both format.