### PR TITLE
Add BASE_URL setting and update templates for proxy sub-url use.

### DIFF
--- a/accountstats/templates/accountstats/account.html
+++ b/accountstats/templates/accountstats/account.html
@@ -7,7 +7,7 @@
 {% block content %}
 {% include "notes_header.html" %}
 {% if user.is_staff%}
-<p><a class="btn btn-primary" href="/secure/notes/new?account={{account}}">{% translate "Create a new note" %}</a></p>
+<p><a class="btn btn-primary" href="{{settings.BASE_URL}}secure/notes/new?account={{account}}">{% translate "Create a new note" %}</a></p>
 {% endif %}
 
 <h1>{% translate "Account use of" %} {{ account }}</h1>
@@ -214,7 +214,7 @@ $(document).ready(function() {
       },
       { data: 'id_job',
         render: function ( data, type, row ) {
-          return '<a href="/secure/jobstats/' + row['username'] + '/' + data + '">' + data + '</a>';
+          return '<a href="{{settings.BASE_URL}}secure/jobstats/' + row['username'] + '/' + data + '">' + data + '</a>';
         }
       },
       { data: 'get_state_display',

--- a/jobstats/templates/jobstats/job.html
+++ b/jobstats/templates/jobstats/job.html
@@ -8,7 +8,7 @@
 {% block content %}
 {% include "notes_header.html" %}
 {% if user.is_staff%}
-  <p><a class="btn btn-primary" href="/secure/notes/new?username={{username}}&job_id={{job_id}}">{% translate "Create a new note" %}</a></p>
+  <p><a class="btn btn-primary" href="{{settings.BASE_URL}}secure/notes/new?username={{username}}&job_id={{job_id}}">{% translate "Create a new note" %}</a></p>
 {% endif %}
 
 {% if multiple_jobs %}
@@ -27,7 +27,7 @@
     <tbody>
       {% for job in jobs %}
       <tr>
-        <td><a href="/secure/jobstats/{{username}}/{{job.id_job}}">{{job.id_job}}</a></td>
+        <td><a href="{{settings.BASE_URL}}secure/jobstats/{{username}}/{{job.id_job}}">{{job.id_job}}</a></td>
         <td>{{job.job_name}}</td>
         <td>{{job.time_submit_dt | date:"c"}}</td>
         <td>{{job.time_in_queue_dt}}</td>
@@ -121,7 +121,7 @@
       <tr>
         <td>
           {% if 'accountstats' in settings.INSTALLED_APPS %}
-            <a href="/secure/accountstats/{{ job.account }}">{{job.account}}</a>
+            <a href="{{settings.BASE_URL}}secure/accountstats/{{ job.account }}">{{job.account}}</a>
           {% else %}
             {{job.account}}
           {% endif %}

--- a/jobstats/templates/jobstats/user.html
+++ b/jobstats/templates/jobstats/user.html
@@ -9,7 +9,7 @@
 
 {% include "notes_header.html" %}
 {% if user.is_staff%}
-<p><a class="btn btn-primary" href="/secure/notes/new?username={{username}}">{% translate "Create a new note" %}</a></p>
+<p><a class="btn btn-primary" href="{{settings.BASE_URL}}secure/notes/new?username={{username}}">{% translate "Create a new note" %}</a></p>
 {% endif %}
 
 <h1>{% translate "Your current use" %}</h1>
@@ -189,7 +189,7 @@ $(document).ready(function() {
     columns: [
       { data: 'id_job',
         render: function ( data, type ) {
-          return '<a href="/secure/jobstats/{{username}}/' + data + '">' + data + '</a>';
+          return '<a href="{{settings.BASE_URL}}secure/jobstats/{{username}}/' + data + '">' + data + '</a>';
         }
       },
       { data: 'get_state_display',

--- a/notes/templates/notes/index.html
+++ b/notes/templates/notes/index.html
@@ -5,7 +5,7 @@
 {% block title %}{% translate "All notes" %}{% endblock title %}
 
 {% block content %}
-<p><a class="btn btn-primary" href="/secure/notes/new">Create a new note</a></p>
+<p><a class="btn btn-primary" href="{{settings.BASE_URL}}secure/notes/new">Create a new note</a></p>
 
 <h2>{% translate "All notes" %}</h2>
 <table table id="notes" class="table table-striped table-bordered" style="width:100%" data-server-side="true" data-ajax="/api/notes/?format=datatables">

--- a/top/templates/top/compute.html
+++ b/top/templates/top/compute.html
@@ -36,7 +36,7 @@
   <tbody>
 {% for user in cpu_users %}
     <tr>
-      <td><a href="/secure/jobstats/{{user.user}}">{{user.user}}
+      <td><a href="{{settings.BASE_URL}}secure/jobstats/{{user.user}}">{{user.user}}
         {% if user.note_flag %}
         <span class="badge badge-primary"><span data-feather="alert-circle" title="User has a note"></span></span>
         {% endif %}</a>

--- a/top/templates/top/gpucompute.html
+++ b/top/templates/top/gpucompute.html
@@ -51,7 +51,7 @@
   <tbody>
 {% for user in gpu_users %}
     <tr>
-      <td><a href="/secure/jobstats/{{user.user}}">{{user.user}}
+      <td><a href="{{settings.BASE_URL}}secure/jobstats/{{user.user}}">{{user.user}}
         {% if user.note_flag %}
         <span class="badge badge-primary"><span data-feather="alert-circle" title="User has a note"></span></span>
         {% endif %}</a>

--- a/top/templates/top/largemem.html
+++ b/top/templates/top/largemem.html
@@ -41,12 +41,12 @@
   <tbody>
 {% for job in jobs %}
     <tr>
-      <td><a href="/secure/jobstats/{{job.user}}">{{job.user}}
+      <td><a href="{{settings.BASE_URL}}secure/jobstats/{{job.user}}">{{job.user}}
         {% if job.user_flag %}
         <span class="badge badge-primary"><span data-feather="alert-circle" title="User has a note"></span></span>
         {% endif %}</a>
       </td>
-      <td><a href="/secure/jobstats/{{job.user}}/{{job.job_id}}">{{job.job_id}}</a>
+      <td><a href="{{settings.BASE_URL}}secure/jobstats/{{job.user}}/{{job.job_id}}">{{job.job_id}}</a>
         {% if job.job_flag %}
         <span class="badge badge-primary"><span data-feather="alert-circle" title="Job has a note"></span></span>
         {% endif %}</a>

--- a/userportal/settings/10-base.py
+++ b/userportal/settings/10-base.py
@@ -149,6 +149,7 @@ LOCALE_PATHS = (
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
+BASE_URL = '/'
 STATIC_URL = '/static/'
 STATIC_ROOT = '/opt/userportal/collected-static/'
 
@@ -178,6 +179,7 @@ SETTINGS_EXPORT = [
     'GPU_COST_PER_HOUR',
     'EXTERNAL_LINKS',
     'OTHER_PORTALS',
+    'BASE_URL',
 ]
 
 INTERNAL_IPS = [

--- a/usersummary/templates/usersummary/user.html
+++ b/usersummary/templates/usersummary/user.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 {% if 'lfs_quota' in settings.EXPORTER_INSTALLED %}
-<h1>{% translate "Your filesystem quotas" %} {% if 'quotas' in settings.INSTALLED_APPS %}<a href="/secure/quotas/{{username}}">({% translate "More details" %})</a>{% endif %}</h1>
+<h1>{% translate "Your filesystem quotas" %} {% if 'quotas' in settings.INSTALLED_APPS %}<a href="{{settings.BASE_URL}}secure/quotas/{{username}}">({% translate "More details" %})</a>{% endif %}</h1>
 <table class="table">
   <thead class="thead-dark">
     <tr>
@@ -44,7 +44,7 @@
 {% endif %}
 
 {% if 'jobstats' in settings.INSTALLED_APPS %}
-<h1>{% translate "Your latest 10 jobs" %} <a href="/secure/jobstats/{{username}}">({% translate "More details" %})</a></h1>
+<h1>{% translate "Your latest 10 jobs" %} <a href="{{settings.BASE_URL}}secure/jobstats/{{username}}">({% translate "More details" %})</a></h1>
 
 <table class="table table-striped">
   <thead class="thead-dark">
@@ -62,7 +62,7 @@
   <tbody>
 {% for job in jobs %}
     <tr>
-      <th scope="row"><a href="/secure/jobstats/{{username}}/{{job.id_job}}">{{job.id_job}}</a></th>
+      <th scope="row"><a href="{{settings.BASE_URL}}secure/jobstats/{{username}}/{{job.id_job}}">{{job.id_job}}</a></th>
       <td><span class="badge badge-{{job.status_badge}}">{{job.status}}</span></td>
       <td>{{job.job_name}}</td>
       <td><span data-toggle="tooltip" data-placement="top" title="{{job.time_submit_dt}}">{{job.time_submit_dt | naturaltime}} <span data-feather="info"></span></span></td>


### PR DESCRIPTION
This patch replaces instances of 'href="/secure/bla/bla"' with 'href="{{settings.BASE_URL}}secure/bla/bla"' in various template html files, as well as setting a default value of '/' in 'userportal/settings/10-base.py'.

This addition of a setting makes it easy to run the application behind a web proxy under a relative URL, e.g. 'some.host.domain/userportal/', instead of having to use a separate domain name, e.g. 'userportal.domain'.