### PR TITLE
Support of Slurm 22.05

### DIFF
--- a/slurm/models.py
+++ b/slurm/models.py
@@ -226,7 +226,6 @@ class JobTable(models.Model):
     wckey = models.TextField()
     work_dir = models.TextField()
     system_comment = models.TextField(blank=True, null=True)
-    track_steps = models.IntegerField()
     tres_alloc = models.TextField()
     tres_req = models.TextField()
 


### PR DESCRIPTION
* The track_steps column was removed in Slurm 22.05. This column was not used in the portal.