### PR TITLE
Added Configuration for Hostname label for Prometheus

### DIFF
--- a/jobstats/views.py
+++ b/jobstats/views.py
@@ -1718,7 +1718,8 @@ def graph_cpu_interconnect(request, username, job_id):
     data = []
 
     # Only measuring the incoming traffic, not the outgoing one since it's only a p2p connection
-    query = '(rate(Incoming_Data_Traffic_On_Link_0{{instance=~"{instances}", {filter} }}[{rate}s]) + rate(Incoming_Data_Traffic_On_Link_1{{instance=~"{instances}", {filter} }}[{rate}s]) + rate(Incoming_Data_Traffic_On_Link_2{{instance=~"{instances}", {filter} }}[{rate}s]))/1024/1024/1024'.format(
+    query = '(rate(Incoming_Data_Traffic_On_Link_0{{{hostname_label}=~"{instances}", {filter} }}[{rate}s]) + rate(Incoming_Data_Traffic_On_Link_1{{{hostname_label}=~"{instances}", {filter} }}[{rate}s]) + rate(Incoming_Data_Traffic_On_Link_2{{{hostname_label}=~"{instances}", {filter} }}[{rate}s]))/1024/1024/1024'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         rate=prom.rate('pcm-sensor-server'))

--- a/jobstats/views.py
+++ b/jobstats/views.py
@@ -174,12 +174,12 @@ def instances_regex(context):
 
 def display_compute_name(lines, line):
     # Display compute name as needed, only if multiple nodes are used
-    names = [entry['metric']['instance'].split(':')[0] for entry in lines]
+    names = [entry['metric'][settings.PROM_NODE_HOSTNAME_LABEL].split(':')[0] for entry in lines]
     if len(set(names)) == 1:
         # if its a single node job, don't return anything
         return ""
     else:
-        return line['metric']['instance'].split(':')[0]
+        return line['metric'][settings.PROM_NODE_HOSTNAME_LABEL].split(':')[0]
 
 
 def display_gpu_id(line):
@@ -290,11 +290,11 @@ def job(request, username, job_id):
         context['cpu_used'] = None
 
     try:
-        query_cpu_bynode = 'count(slurm_job_core_usage_total{{slurmjobid="{}", {}}}) by (instance)'.format(job_id, prom.get_filter())
+        query_cpu_bynode = 'count(slurm_job_core_usage_total{{slurmjobid="{}", {}}}) by ({})'.format(job_id, prom.get_filter(), settings.PROM_NODE_HOSTNAME_LABEL)
         stats_cpu_bynode = prom.query_prometheus_multiple(query_cpu_bynode, job.time_start_dt(), job.time_end_dt())
         cpu_bynode = []
         for node in stats_cpu_bynode:
-            node_name = node['metric']['instance'].split(':')[0]
+            node_name = node['metric'][settings.PROM_NODE_HOSTNAME_LABEL].split(':')[0]
             cpu_bynode.append({'name': node_name, 'count': int(node['y'][0])})
         context['cpu_bynode'] = cpu_bynode
         context['nb_nodes'] = len(cpu_bynode)
@@ -1254,7 +1254,8 @@ def graph_ethernet_bdw(request, username, job_id):
     data = []
     step = sanitize_step(request, minimum=prom.rate('node_exporter'))
 
-    query_received = 'rate(node_network_receive_bytes_total{{device!~"ib.*|lo", instance=~"{instances}", {filter}}}[{step}s]) * 8 / (1000*1000)'.format(
+    query_received = 'rate(node_network_receive_bytes_total{{device!~"ib.*|lo", {hostname_label}=~"{instances}", {filter}}}[{step}s]) * 8 / (1000*1000)'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1271,7 +1272,8 @@ def graph_ethernet_bdw(request, username, job_id):
             'hovertemplate': '%{y:.1f}',
         })
 
-    query_transmitted = '-rate(node_network_transmit_bytes_total{{device!~"ib.*|lo", instance=~"{instances}", {filter}}}[{step}s]) * 8 /(1000*1000)'.format(
+    query_transmitted = '-rate(node_network_transmit_bytes_total{{device!~"ib.*|lo", {hostname_label}=~"{instances}", {filter}}}[{step}s]) * 8 /(1000*1000)'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1307,7 +1309,8 @@ def graph_infiniband_bdw(request, username, job_id):
     data = []
     step = sanitize_step(request, minimum=prom.rate('node_exporter'))
 
-    query_received = 'rate(node_infiniband_port_data_received_bytes_total{{instance=~"{instances}", {filter}}}[{step}s]) * 8 / (1000*1000*1000)'.format(
+    query_received = 'rate(node_infiniband_port_data_received_bytes_total{{{hostname_label}=~"{instances}", {filter}}}[{step}s]) * 8 / (1000*1000*1000)'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1324,7 +1327,8 @@ def graph_infiniband_bdw(request, username, job_id):
             'hovertemplate': '%{y:.1f}',
         })
 
-    query_transmitted = '-rate(node_infiniband_port_data_transmitted_bytes_total{{instance=~"{instances}", {filter}}}[{step}s]) * 8 /(1000*1000*1000)'.format(
+    query_transmitted = '-rate(node_infiniband_port_data_transmitted_bytes_total{{{hostname_label}=~"{instances}", {filter}}}[{step}s]) * 8 /(1000*1000*1000)'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1360,7 +1364,7 @@ def graph_disk_iops(request, username, job_id):
     data = []
     step = sanitize_step(request, minimum=prom.rate('node_exporter'))
 
-    query_read = 'rate(node_disk_reads_completed_total{{instance=~"{}",device=~"nvme.n.|sd.|vd.", {}}}[{}s])'.format(instances, prom.get_filter(), step)
+    query_read = 'rate(node_disk_reads_completed_total{{{}=~"{}",device=~"nvme.n.|sd.|vd.", {}}}[{}s])'.format(settings.PROM_NODE_HOSTNAME_LABEL, instances, prom.get_filter(), step)
     stats_read = prom.query_prometheus_multiple(query_read, context['job'].time_start_dt(), context['job'].time_end_dt(), step=step)
     for line in stats_read:
         compute_name = "{} {}".format(
@@ -1376,7 +1380,7 @@ def graph_disk_iops(request, username, job_id):
             'hovertemplate': '%{y:.1f} IOPS',
         })
 
-    query_write = 'rate(node_disk_writes_completed_total{{instance=~"{}",device=~"nvme.n.|sd.|vd.", {}}}[{}s])'.format(instances, prom.get_filter(), step)
+    query_write = 'rate(node_disk_writes_completed_total{{{}=~"{}",device=~"nvme.n.|sd.|vd.", {}}}[{}s])'.format(settings.PROM_NODE_HOSTNAME_LABEL, instances, prom.get_filter(), step)
     stats_write = prom.query_prometheus_multiple(query_write, context['job'].time_start_dt(), context['job'].time_end_dt(), step=step)
     for line in stats_write:
         compute_name = "{} {}".format(
@@ -1410,7 +1414,8 @@ def graph_disk_bdw(request, username, job_id):
     data = []
     step = sanitize_step(request, minimum=prom.rate('node_exporter'))
 
-    query_read = 'rate(node_disk_read_bytes_total{{instance=~"{instances}",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}s])'.format(
+    query_read = 'rate(node_disk_read_bytes_total{{{hostname_label}=~"{instances}",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}s])'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1429,7 +1434,8 @@ def graph_disk_bdw(request, username, job_id):
             'hovertemplate': '%{y:.1f}',
         })
 
-    query_write = '-rate(node_disk_written_bytes_total{{instance=~"{instances}",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}s])'.format(
+    query_write = '-rate(node_disk_written_bytes_total{{{hostname_label}=~"{instances}",device=~"nvme.n.|sd.|vd.", {filter}}}[{step}s])'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         step=step)
@@ -1466,7 +1472,8 @@ def graph_disk_used(request, username, job_id):
 
     data = []
 
-    query_disk = '(node_filesystem_size_bytes{{instance=~"{instances}",mountpoint="/localscratch", {filter}}} - node_filesystem_avail_bytes{{instance=~"{instances}",mountpoint="/localscratch", {filter}}})/(1000*1000*1000)'.format(
+    query_disk = '(node_filesystem_size_bytes{{{hostname_label}=~"{instances}",mountpoint="/localscratch", {filter}}} - node_filesystem_avail_bytes{{{hostname_label}=~"{instances}",mountpoint="/localscratch", {filter}}})/(1000*1000*1000)'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter())
     stats_disk = prom.query_prometheus_multiple(query_disk, context['job'].time_start_dt(), context['job'].time_end_dt(), step=sanitize_step(request, minimum=prom.rate('node_exporter')))
@@ -1503,7 +1510,8 @@ def graph_mem_bdw(request, username, job_id):
     data = []
 
     for direction in ['Reads', 'Writes']:
-        query = 'rate(DRAM_{direction}{{instance=~"{instances}", {filter} }}[1m])/1024/1024/1024'.format(
+        query = 'rate(DRAM_{direction}{{{hostname_label}=~"{instances}", {filter} }}[1m])/1024/1024/1024'.format(
+            hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
             direction=direction,
             instances=instances,
             filter=prom.get_filter())
@@ -1550,7 +1558,8 @@ def graph_l3_rate(request, username, job_id):
 def map_pcm_cores(request, context):
     instances = instances_regex(context)
     # get the OS core mapping to the physical cores since they don't match
-    query_mapping = 'OS_ID{{instance=~"{instances}", {filter}}}'.format(
+    query_mapping = 'OS_ID{{{hostname_label}=~"{instances}", {filter}}}'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter())
     stats_mapping = prom.query_prometheus_multiple(
@@ -1631,7 +1640,8 @@ def graph_cache_rate(request, username, job_id, l_cache):
 
     # get all the L3 cache hits and misses, we will discard the ones not used
     # by the job since we can't easily filter them out with a regex in the query
-    query_cache = 'rate({l_cache}_Cache_Hits{{instance=~"{instances}", core=~"[0-9]+", {filter}}}[{rate}s])/(rate({l_cache}_Cache_Hits{{instance=~"{instances}", core=~"[0-9]+", {filter}}}[{rate}s]) + rate({l_cache}_Cache_Misses{{instance=~"{instances}", core=~"[0-9]+", {filter}}}[{rate}s])) * 100'.format(
+    query_cache = 'rate({l_cache}_Cache_Hits{{{hostname_label}=~"{instances}", core=~"[0-9]+", {filter}}}[{rate}s])/(rate({l_cache}_Cache_Hits{{{hostname_label}=~"{instances}", core=~"[0-9]+", {filter}}}[{rate}s]) + rate({l_cache}_Cache_Misses{{{hostname_label}=~"{instances}", core=~"[0-9]+", {filter}}}[{rate}s])) * 100'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         l_cache=l_cache,
         instances=instances,
         filter=prom.get_filter(),
@@ -1669,7 +1679,8 @@ def graph_ipc(request, username, job_id):
     # We compute the IPC instead of the CPI to show a graph with "higher is better"
     # so read that documentation and invert their formula and ratio
     # https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/reference/cpu-metrics-reference.html#cpu-metrics-reference_CLOCKTICKS-PER-INSTRUCTIONS-RETIRED-CPI
-    query_ipc = 'rate(Instructions_Retired_Any{{instance=~"{instances}",core=~"[0-9]+", {filter} }}[{rate}s]) / rate(Clock_Unhalted_Ref{{instance=~"{instances}",core=~"[0-9]+", {filter} }}[{rate}s])'.format(
+    query_ipc = 'rate(Instructions_Retired_Any{{{hostname_label}=~"{instances}",core=~"[0-9]+", {filter} }}[{rate}s]) / rate(Clock_Unhalted_Ref{{{hostname_label}=~"{instances}",core=~"[0-9]+", {filter} }}[{rate}s])'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         instances=instances,
         filter=prom.get_filter(),
         rate=prom.rate('pcm-sensor-server'))
@@ -1769,7 +1780,7 @@ def graph_power(request, username, job_id):
 
     data = []
     for line in power(job, step=sanitize_step(request, minimum=prom.rate('redfish_exporter'))):
-        compute_name = "{}".format(line['metric']['instance'])
+        compute_name = "{}".format(line['metric'][settings.PROM_NODE_HOSTNAME_LABEL])
         x = list(map(lambda x: x.strftime('%Y-%m-%d %H:%M:%S'), line['x']))
         data.append({
             'x': x,

--- a/pages/views.py
+++ b/pages/views.py
@@ -130,13 +130,15 @@ def graph_login_cpu(request, login):
         return JsonResponse({'error': 'Unknown login node'})
     timing = query_time(request)
 
-    core_count_query = 'count(node_cpu_seconds_total{{mode="system",instance=~"{login}(:.*)?", {filter} }})'.format(
+    core_count_query = 'count(node_cpu_seconds_total{{mode="system",{hostname_label}=~"{login}(:.*)?", {filter} }})'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         login=login,
         filter=prom.get_filter(),
     )
     core_count = max(prom.query_prometheus(core_count_query, timing[0], step=timing[1])[1])
     data = []
-    query = 'sum by (mode)(rate(node_cpu_seconds_total{{mode=~"system|user|iowait",instance=~"{login}(:.*)?", {filter} }}[{step}s]))'.format(
+    query = 'sum by (mode)(rate(node_cpu_seconds_total{{mode=~"system|user|iowait",{hostname_label}=~"{login}(:.*)?", {filter} }}[{step}s]))'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         login=login,
         filter=prom.get_filter(),
         step=timing[1],
@@ -187,7 +189,8 @@ def graph_login_memory(request, login):
     )
     total_mem = max(prom.query_prometheus(total_mem_query, timing[0], step=timing[1])[1])
     data = []
-    query = 'node_memory_MemTotal_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_MemFree_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_Buffers_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_Cached_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_Slab_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_PageTables_bytes{{instance=~"{login}(:.*)?", {filter} }} - node_memory_SwapCached_bytes{{instance=~"{login}(:.*)?", {filter} }}'.format(
+    query = 'node_memory_MemTotal_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }} - node_memory_MemFree_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }} - node_memory_Buffers_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }} - node_memory_Cached_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }} - node_memory_Slab_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }} - node_memory_PageTables_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }} - node_memory_SwapCached_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }}'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         login=login,
         filter=prom.get_filter(),
     )
@@ -226,7 +229,8 @@ def graph_login_load(request, login):
     timing = query_time(request)
     data = []
 
-    query = 'node_load1{{instance=~"{login}(:.*)?", {filter} }}'.format(
+    query = 'node_load1{{{hostname_label}=~"{login}(:.*)?", {filter} }}'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         login=login,
         filter=prom.get_filter(),
     )
@@ -275,7 +279,8 @@ def graph_dtn_network(request, dtn):
 def graph_network(request, node, device):
     timing = query_time(request)
     data = []
-    query_rx = 'rate(node_network_receive_bytes_total{{instance=~"{node}(:.*)?", device="{device}", {filter} }}[{step}s]) * 8'.format(
+    query_rx = 'rate(node_network_receive_bytes_total{{{hostname_label}=~"{node}(:.*)?", device="{device}", {filter} }}[{step}s]) * 8'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         node=node,
         filter=prom.get_filter(),
         device=device,
@@ -291,7 +296,8 @@ def graph_network(request, node, device):
         'name': '{}'.format('Receive'),
     })
 
-    query_tx = 'rate(node_network_transmit_bytes_total{{instance=~"{node}(:.*)?", device="{device}", {filter} }}[{step}s]) * 8'.format(
+    query_tx = 'rate(node_network_transmit_bytes_total{{{hostname_label}=~"{node}(:.*)?", device="{device}", {filter} }}[{step}s]) * 8'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         node=node,
         filter=prom.get_filter(),
         device=device,

--- a/userportal/settings/21-prometheus.py
+++ b/userportal/settings/21-prometheus.py
@@ -3,3 +3,5 @@ PROMETHEUS = {
     'headers': {'Authorization': 'Basic changeme_base64'},
     'filter': "cluster='narval'",
 }
+
+PROM_NODE_HOSTNAME_LABEL = 'name'

--- a/userportal/settings/21-prometheus.py
+++ b/userportal/settings/21-prometheus.py
@@ -4,4 +4,4 @@ PROMETHEUS = {
     'filter': "cluster='narval'",
 }
 
-PROM_NODE_HOSTNAME_LABEL = 'name'
+PROM_NODE_HOSTNAME_LABEL = 'instance'


### PR DESCRIPTION
Hi. I've added a configuration option for which Prometheus label contains the node hostname. This adds support for clusters where Prometheus metric endpoints are targeted by IP instead of hostname, thus the hostname is not in the `instance` label.

The default configuration remains to use `instance`.