### PR TITLE
Add Support for Authentication Using Cloudflare Access

### DIFF
--- a/cfaccess/backends.py
+++ b/cfaccess/backends.py
@@ -23,9 +23,9 @@ class CloudflareAccessLDAPBackend(ModelBackend):
         created = False
         username = self.clean_username(cloudflare_user)
 
-        # Temporary fix to restrict CILogon
-        if cloudflare_user.split('@')[1] != 'alliancecan.ca':
-            return
+        if settings.CF_ACCESS_CONFIG['require_trusted_suffix']:
+            if cloudflare_user.split('@')[1] not in settings.CF_ACCESS_CONFIG['trusted_suffix']:
+                return
 
         if self.create_unknown_user:
             user, created = UserModel._default_manager.get_or_create(

--- a/cfaccess/backends.py
+++ b/cfaccess/backends.py
@@ -1,0 +1,72 @@
+from typing import Any, Optional, Union
+from django.contrib.auth.backends import RemoteUserBackend, ModelBackend
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.auth.models import User
+from django.http.request import HttpRequest
+
+from django.conf import settings
+
+from django.contrib.auth import get_user_model
+UserModel = get_user_model()
+
+from ccldap.models import LdapUser
+
+class CloudflareAccessLDAPBackend(ModelBackend):
+
+    create_unknown_user = True
+
+    def authenticate(self, request: HttpRequest, cloudflare_user: str, jwt_data=None, **kwargs) -> Union[User, None]:
+        if not cloudflare_user:
+            return
+        
+        user = None
+        created = False
+        username = self.clean_username(cloudflare_user)
+
+        # Temporary fix to restrict CILogon
+        if cloudflare_user.split('@')[1] != 'alliancecan.ca':
+            return
+
+        if self.create_unknown_user:
+            user, created = UserModel._default_manager.get_or_create(
+                **{UserModel.USERNAME_FIELD: username}
+            )
+        else:
+            try:
+                user = UserModel._default_manager.get_by_natural_key(username)
+            except UserModel.DoesNotExist:
+                pass
+
+        user = self.configure_user(request, user, created=created, jwt_data=jwt_data)
+        return user if self.user_can_authenticate(user) else None
+
+    def configure_user(self, request: HttpRequest, user: User, created=True, jwt_data=None) -> User:
+        ldapuser = LdapUser.objects.get(username=user.username)
+
+        try:
+            user.first_name = ldapuser.given_name
+        except:
+            user.first_name = ''
+        
+        try:
+            user.last_name = ldapuser.surname
+        except:
+            user.last_name = ''
+
+        if jwt_data:
+            has_staff_attr = False
+            for attribute, value in settings.CF_ACCESS_CONFIG['staff_attributes']:
+                if (attribute in jwt_data['custom']):
+                    if (type(jwt_data['custom'][attribute]) == list) and (value in jwt_data['custom'][attribute]):
+                        has_staff_attr = True
+                    elif (type(jwt_data['custom'][attribute]) == str) and (value == jwt_data['custom'][attribute]):
+                        has_staff_attr = True
+
+            user.is_staff = has_staff_attr
+
+        user.save()
+
+        return user
+
+    def clean_username(self, username):
+        return username.split('@')[0]

--- a/cfaccess/backends.py
+++ b/cfaccess/backends.py
@@ -1,15 +1,16 @@
-from typing import Any, Optional, Union
-from django.contrib.auth.backends import RemoteUserBackend, ModelBackend
-from django.contrib.auth.base_user import AbstractBaseUser
+from typing import Union
+from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import User
 from django.http.request import HttpRequest
 
 from django.conf import settings
 
 from django.contrib.auth import get_user_model
-UserModel = get_user_model()
 
 from ccldap.models import LdapUser
+
+UserModel = get_user_model()
+
 
 class CloudflareAccessLDAPBackend(ModelBackend):
 
@@ -18,7 +19,7 @@ class CloudflareAccessLDAPBackend(ModelBackend):
     def authenticate(self, request: HttpRequest, cloudflare_user: str, jwt_data=None, **kwargs) -> Union[User, None]:
         if not cloudflare_user:
             return
-        
+
         user = None
         created = False
         username = self.clean_username(cloudflare_user)
@@ -45,12 +46,12 @@ class CloudflareAccessLDAPBackend(ModelBackend):
 
         try:
             user.first_name = ldapuser.given_name
-        except:
+        except Exception:
             user.first_name = ''
-        
+
         try:
             user.last_name = ldapuser.surname
-        except:
+        except Exception:
             user.last_name = ''
 
         if jwt_data:

--- a/cfaccess/backends.py
+++ b/cfaccess/backends.py
@@ -58,9 +58,9 @@ class CloudflareAccessLDAPBackend(ModelBackend):
             has_staff_attr = False
             for attribute, value in settings.CF_ACCESS_CONFIG['staff_attributes']:
                 if (attribute in jwt_data['custom']):
-                    if (type(jwt_data['custom'][attribute]) == list) and (value in jwt_data['custom'][attribute]):
+                    if (type(jwt_data['custom'][attribute]) is list) and (value in jwt_data['custom'][attribute]):
                         has_staff_attr = True
-                    elif (type(jwt_data['custom'][attribute]) == str) and (value == jwt_data['custom'][attribute]):
+                    elif (type(jwt_data['custom'][attribute]) is str) and (value == jwt_data['custom'][attribute]):
                         has_staff_attr = True
 
             user.is_staff = has_staff_attr

--- a/cfaccess/middleware.py
+++ b/cfaccess/middleware.py
@@ -1,0 +1,127 @@
+from django.http import HttpResponse, JsonResponse, HttpResponseForbidden, HttpRequest
+from django.conf import settings
+
+from django.contrib.auth import login, logout, authenticate
+from django.contrib.auth.models import User
+
+from cfaccess.backends import CloudflareAccessLDAPBackend
+
+import requests
+import jwt
+import json
+
+import time
+
+class CloudflareAccessLDAPMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def clean_username(self, username):
+        backend = CloudflareAccessLDAPBackend()
+        return backend.clean_username(username)
+    
+    def __call__(self, request: HttpRequest):
+        """
+        This middleware will check for a valid Cloudflare Access JWT.
+
+        If valid JWT is NOT presented, and Cloudflare Access enforcement
+        is enabled, a 403 Forbidden will be returned for all requests.
+
+        If a valid JWT is NOT presented, and Cloudflare Access enforcement
+        is disabled, the session will be allowed to continue, weather it is
+        authenticated or not.
+
+        If a valid JWT is presented, and matches the currently authenticated
+        user, the session is allowed to continue.
+        
+        If a valid JWT is presented, and the user is not currently
+        authenticated, this middleware will attempt to authenticate the
+        user.
+
+        If a valid JWT is presented, but it does not match the currently
+        authenticated user, the session will be logged out and
+        authentication will be attempted with the new user.
+        """
+
+        # check for no JWT
+        if "CF_Authorization" not in request.COOKIES:
+            return self._handle_no_token(request)
+        
+        # validate presented JWT
+        # ts = time.time()
+        token = request.COOKIES["CF_Authorization"]
+        keys = self._get_public_keys()
+        policy_aud = settings.CF_ACCESS_CONFIG['policy_aud']
+
+        jwt_data = self._validate_JWT(token, keys, policy_aud)
+        
+        # handle as no / invalid token
+        if not jwt_data:
+            return self._handle_no_token(request)
+
+        jwt_username = jwt_data[settings.CF_ACCESS_CONFIG['username_attribute']]
+        # print(f'token validation took: {time.time() - ts}')
+
+
+        # if the user is authenticated, but does not match the token, logout the previous
+        # user and login the new session
+        if request.user.get_username() != self.clean_username(jwt_username):
+            # print("Logging out")
+            # ts = time.time()
+            logout(request)
+            # print(f'logout took: {time.time() - ts}')
+
+        # We have a valid JWT, check if the user is not currently authenticated, if so,
+        # login the user to their session
+        if not request.user.is_authenticated:
+            # ts = time.time()
+            user = authenticate(request, cloudflare_user=jwt_username, jwt_data=jwt_data)
+            request.user = user
+            login(request, user)
+            # print(f'login took: {time.time() - ts}')
+            print(user, request.user.is_authenticated)
+
+        # The user is already authenticated as the correct user, proceed with session
+        return self.get_response(request)
+
+
+    def _handle_no_token(self, request):
+        if settings.CF_ACCESS_CONFIG['enforce_cloudflare_access']:
+            return HttpResponseForbidden()
+        else:
+            return self.get_response(request)
+            
+
+    def _validate_JWT(self, jwt_token, keys, aud):
+        """
+        Checks if provided Cloudflare Access JWT is valid. A JWT is determined
+        to be valid if it is signed by any of the provided keys and the JWT 
+        "aud" matches the provided "aud".
+
+        if the JWT is valid, it's payload is returned.
+
+        A invalid token will return None
+        """
+        for key in keys:
+            try:
+                # decode returns the claims that has the email when needed
+                token_data = jwt.decode(jwt_token, key=key, audience=aud, algorithms=['RS256'])
+                return token_data
+            except:
+                pass
+
+    def _get_public_keys(self):
+        """
+        Returns:
+            List of RSA public keys usable by PyJWT.
+        """
+        request_url = "{}/cdn-cgi/access/certs".format(settings.CF_ACCESS_CONFIG['team_domain'])
+
+        r = requests.get(request_url)
+        public_keys = []
+        jwk_set = r.json()
+        for key_dict in jwk_set['keys']:
+            public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key_dict))
+            public_keys.append(public_key)
+        return public_keys
+

--- a/cfaccess/middleware.py
+++ b/cfaccess/middleware.py
@@ -60,26 +60,19 @@ class CloudflareAccessLDAPMiddleware:
             return self._handle_no_token(request)
 
         jwt_username = jwt_data[settings.CF_ACCESS_CONFIG['username_attribute']]
-        # print(f'token validation took: {time.time() - ts}')
 
 
         # if the user is authenticated, but does not match the token, logout the previous
         # user and login the new session
         if request.user.get_username() != self.clean_username(jwt_username):
-            # print("Logging out")
-            # ts = time.time()
             logout(request)
-            # print(f'logout took: {time.time() - ts}')
 
         # We have a valid JWT, check if the user is not currently authenticated, if so,
         # login the user to their session
         if not request.user.is_authenticated:
-            # ts = time.time()
             user = authenticate(request, cloudflare_user=jwt_username, jwt_data=jwt_data)
             request.user = user
             login(request, user)
-            # print(f'login took: {time.time() - ts}')
-            print(user, request.user.is_authenticated)
 
         # The user is already authenticated as the correct user, proceed with session
         return self.get_response(request)

--- a/cfaccess/tests_backends.py
+++ b/cfaccess/tests_backends.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from cfaccess.backends import CloudflareAccessLDAPBackend
+
+class CloudflareAccessLDAPBackendTestCase(TestCase):
+    def setUp(self):
+        pass
+
+    def test_clean_username(self):
+        

--- a/cfaccess/tests_backends.py
+++ b/cfaccess/tests_backends.py
@@ -1,9 +1,0 @@
-from django.test import TestCase
-from cfaccess.backends import CloudflareAccessLDAPBackend
-
-class CloudflareAccessLDAPBackendTestCase(TestCase):
-    def setUp(self):
-        pass
-
-    def test_clean_username(self):
-        

--- a/docs/cfaccess.md
+++ b/docs/cfaccess.md
@@ -1,0 +1,50 @@
+# Cloudflare Access
+
+`cfaccess` is a optional feature of TrailblazingTurtle developed and contributed by [ACENET](https://ace-net.ca) for use on [Siku](https://wiki.ace-net.ca/wiki/Siku).
+
+To use it on your own cluster, you will need a Cloudflare Account and Access Subscription.
+
+## How it Works
+
+Cloudflare Access provides a cloud reverse proxy which can authenticate the User before requests can hit your application server.
+
+When a request passes through Cloudflare Access, Cloudflare's reverse proxy will add a header (`Cf-Access-Jwt-Assertion`) and cookie (`CF_Authorization`) containing a [JWT](https://jwt.io/) (Json Web Token). The JWT is composed of Base64 encoded JSON signed by Cloudflare and contains attributes about the authenticated user.
+
+Here is an example of the data encoded in the JWT:
+
+```json
+{
+  "aud": [
+    "32eafc7626e974616deaf0dc3ce63d7bcbed58a2731e84d06bc3cdf1b53c4228"
+  ],
+  "email": "user@example.com",
+  "exp": 1659474457,
+  "iat": 1659474397,
+  "nbf": 1659474397,
+  "iss": "https://yourteam.cloudflareaccess.com",
+  "type": "app",
+  "identity_nonce": "6ei69kawdKzMIAPF",
+  "sub": "7335d417-61da-459d-899c-0a01c76a2f94",
+  "country": "US"
+}
+```
+
+You can learn more about the validation of the JWT [here](https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/).
+
+Custom attributes from the identity provider can also be passed in the JWT, such as `eduPersonPrincipalName` or Compute Canada specific attributes such as `ccServiceAccess`, . You can learn more about the validation of the JWT [here](https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/).
+
+## Configuration
+
+You must configure your application to be accessable to Cloudflare. Cloudflare provides [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), a daemon which connects out to the Cloudflare Network and tunnels traffic back to your application, no Public IP address required.
+
+Configure your IDP(s) and Enable Cloudflare Access for your application.
+
+You will need to select a attribute from your IDP, which matches the username in LDAP. For Alliance IDP, you can pass `eduPersonPrincipalName`, which for alliance users will be `<ldap uid>@alliancecan.ca`.
+
+configuration your Cloudflare Access organization, Policy AUD, and Staff Attributes in `41-cloudflareaccess.py`.
+
+You must:
+
+  - Remove `djangosaml2.middleware.SamlSessionMiddleware` from `MIDDLEWARE`
+  - Add `cfaccess.middleware.CloudflareAccessLDAPMiddleware` to `MIDDLEWARE`
+  - Add `cfaccess.backends.CloudflareAccessLDAPBackend` to `AUTHENTICATION_BACKENDS`

--- a/docs/cfaccess.md
+++ b/docs/cfaccess.md
@@ -35,7 +35,7 @@ Custom attributes from the identity provider can also be passed in the JWT, such
 
 ## Configuration
 
-You must configure your application to be accessable to Cloudflare. Cloudflare provides [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), a daemon which connects out to the Cloudflare Network and tunnels traffic back to your application, no Public IP address required.
+You must configure your application to be accessible to Cloudflare. Cloudflare provides [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), a daemon which connects out to the Cloudflare Network and tunnels traffic back to your application, no Public IP address required.
 
 Configure your IDP(s) and Enable Cloudflare Access for your application.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pyasn1-modules==0.2.8
 pycodestyle==2.7.0
 pycparser==2.21
 pyflakes==2.3.0
+pyjwt==2.7.0
 Pyment==0.3.3
 pyOpenSSL==22.0.0
 pysaml2==7.1.2

--- a/userportal/settings/41-cloudflareaccess.py
+++ b/userportal/settings/41-cloudflareaccess.py
@@ -1,0 +1,19 @@
+# Cloudflare Authentication is Disabled by default
+# For instructions to enable, see docs/cfaccess.md
+
+CF_ACCESS_CONFIG = {
+    'team_domain': 'https://<your-org>.cloudflareaccess.com',
+    'policy_aud': 'get-this-from-cloudflare-dashboard',
+
+    'username_attribute': 'email',
+    ''
+
+    # if this option is true, all requests that do not contain a valid JWT will get a 403 Forbidden
+    'enforce_cloudflare_access': False,
+
+    # Use this to assign the staff role based on attributes from the Cloudflare JWT.
+    # If ANY one of these attributes match, user is_staff will be set to True
+    'staff_attributes': [
+        ('ccServiceAccess', '<your-cluster>-portal-staff')
+    ]
+}

--- a/userportal/settings/41-cloudflareaccess.py
+++ b/userportal/settings/41-cloudflareaccess.py
@@ -5,8 +5,9 @@ CF_ACCESS_CONFIG = {
     'team_domain': 'https://<your-org>.cloudflareaccess.com',
     'policy_aud': 'get-this-from-cloudflare-dashboard',
 
-    'username_attribute': 'email',
-    ''
+    'username_attribute': 'eduPersonPrincipalName',
+    'require_trusted_suffix': True,
+    'trusted_suffix': ["alliancecan.ca"],
 
     # if this option is true, all requests that do not contain a valid JWT will get a 403 Forbidden
     'enforce_cloudflare_access': False,


### PR DESCRIPTION
This adds an optional module (disabled by default), allowing the portal to use JWT's from Cloudflare Access to authenticate users. Configuration is documented in `docs/cfaccess.md`.