### PR TITLE
Fix Cloudflare Zero-Trust authentication and Prometheus query without instance

### DIFF
--- a/cfaccess/middleware.py
+++ b/cfaccess/middleware.py
@@ -66,10 +66,12 @@ class CloudflareAccessLDAPMiddleware:
         # We have a valid JWT, check if the user is not currently authenticated, if so,
         # login the user to their session
         if not request.user.is_authenticated:
-            user = authenticate(request, cloudflare_user=jwt_username, jwt_data=jwt_data)
-            request.user = user
-            login(request, user)
-
+            backend = CloudflareAccessLDAPBackend()
+            user = backend.authenticate(request, cloudflare_user=jwt_username, jwt_data=jwt_data)
+            if user is not None:
+                user.backend = 'cfaccess.backends.CloudflareAccessLDAPBackend'
+                request.user = user
+                login(request, user)
         # The user is already authenticated as the correct user, proceed with session
         return self.get_response(request)
 

--- a/cfaccess/middleware.py
+++ b/cfaccess/middleware.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponseForbidden, HttpRequest
 from django.conf import settings
 
-from django.contrib.auth import login, logout, authenticate
+from django.contrib.auth import login, logout
 
 from cfaccess.backends import CloudflareAccessLDAPBackend
 

--- a/pages/views.py
+++ b/pages/views.py
@@ -201,7 +201,8 @@ def graph_login_memory(request, login):
     if login not in settings.LOGINS.keys():
         return JsonResponse({'error': 'Unknown login node'})
 
-    total_mem_query = 'node_memory_MemTotal_bytes{{instance=~"{login}(:.*)?", {filter} }}'.format(
+    total_mem_query = 'node_memory_MemTotal_bytes{{{hostname_label}=~"{login}(:.*)?", {filter} }}'.format(
+        hostname_label=settings.PROM_NODE_HOSTNAME_LABEL,
         login=login,
         filter=prom.get_filter(),
     )


### PR DESCRIPTION
This PR fixes the cfaccess module not using the correct authentication backend when authenticating using the cloudflare middleware, as well as allows for a configurable instance variable similar to the rest of the queries for the node exporter mem total query.