### PR TITLE
Jobstats: Using the GSI-HPC fork of lustre_exporter

### DIFF
--- a/accountstats/views.py
+++ b/accountstats/views.py
@@ -166,6 +166,8 @@ def graph_lustre_ost(request, account):
             step=request.step)
 
         for line in stats:
+            if 'fs' not in line['metric']:
+                continue
             fs = line['metric']['fs']
             user = a(line['metric']['user'])
             x = list(map(lambda x: x.strftime('%Y-%m-%d %H:%M:%S'), line['x']))

--- a/docs/data.md
+++ b/docs/data.md
@@ -56,7 +56,7 @@ This MySQL database is accessed by a read-only user. It does not need to be in t
 ## lustre\_exporter and lustre\_exporter\_slurm
 Those 2 exporters are used to gather information about Lustre usage.
 
-* [lustre\_exporter](https://github.com/HewlettPackard/lustre_exporter) capture information on Lustre MDS and OSS but will only use \$SLURM\_JOBID as a tag on the metrics.
+* [lustre\_exporter](https://github.com/GSI-HPC/lustre_exporter/) capture information on Lustre MDS and OSS but will only use \$SLURM\_JOBID as a tag on the metrics.
 * [lustre\_exporter\_slurm](https://github.com/guilbaults/lustre_exporter_slurm) is used as a proxy between Prometheus and lustre_exporter to improve the content of the tags. This will match the \$SLURM\_JOBID to a job in Slurm and will add the username and Slurm account in the tags.
 
 The following recorder rules are used to pre-aggregate stats shown in the user portal.

--- a/jobstats/views.py
+++ b/jobstats/views.py
@@ -880,6 +880,8 @@ def graph_lustre_mdt(request, username, job_id):
 
     data = []
     for line in stats:
+        if 'fs' not in line['metric']:
+            continue
         operation = line['metric']['operation']
         fs = line['metric']['fs']
         x = list(map(lambda x: x.strftime('%Y-%m-%d %H:%M:%S'), line['x']))
@@ -913,6 +915,8 @@ def graph_lustre_mdt_user(request, username):
     stats = prom.query_prometheus_multiple(query, request.start, request.end, step=request.step)
     data = []
     for line in stats:
+        if 'fs' not in line['metric']:
+            continue
         operation = line['metric']['operation']
         fs = line['metric']['fs']
         x = list(map(lambda x: x.strftime('%Y-%m-%d %H:%M:%S'), line['x']))
@@ -953,6 +957,8 @@ def graph_lustre_ost(request, username, job_id):
             step=max(context['step'], prom.rate('lustre_exporter')))
 
         for line in stats:
+            if 'fs' not in line['metric']:
+                continue
             fs = line['metric']['fs']
             if i == 'read':
                 y = line['y']
@@ -995,6 +1001,8 @@ def graph_lustre_ost_user(request, username):
         stats = prom.query_prometheus_multiple(query, request.start, request.end, step=request.step)
 
         for line in stats:
+            if 'fs' not in line['metric']:
+                continue
             fs = line['metric']['fs']
             x = list(map(lambda x: x.strftime('%Y-%m-%d %H:%M:%S'), line['x']))
             if i == 'read':


### PR DESCRIPTION
The main git repo by HPE is no longer supported, we are switching to the fork by GSI-HPC. This fork don't return stats when it's zero, so we need handle this small change.