### PR TITLE
Restrict some github actions to read-only on the repo

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -2,6 +2,9 @@ name: flake8 Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   flake8-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Suggested by CodeQL, the flake and spelling GitHub actions does not need to be able to modify the repo. 