### PR TITLE
Remove lft/rgt fields from AssocTable to support slurm >=23.11

### DIFF
--- a/slurm/models.py
+++ b/slurm/models.py
@@ -78,8 +78,6 @@ class AssocTable(models.Model):
     acct = models.TextField()
     partition = models.TextField()
     parent_acct = models.TextField()
-    lft = models.IntegerField()
-    rgt = models.IntegerField()
     shares = models.IntegerField()
     max_jobs = models.IntegerField(blank=True, null=True)
     max_jobs_accrue = models.IntegerField(blank=True, null=True)


### PR DESCRIPTION
Slurm commit [a1c8a63f41a808209915633305db4dd0447c70d4](https://github.com/SchedMD/slurm/commit/a1c8a63f41a808209915633305db4dd0447c70d4) removed these fields hence they no longer exist in the database on slurm 23.11 and newer.  This prevents account stats from loading successfully on newer slurm versions.

Since these fields don't seem to be used by anything, removing them should be safe even for older versions of slurm.